### PR TITLE
Fix importing in quiz.ts

### DIFF
--- a/src/mockup_data/quiz.ts
+++ b/src/mockup_data/quiz.ts
@@ -1,4 +1,4 @@
-import { User, user1 } from "./user.js";
+import { User, user1 } from "./user";
 
 // --------------- INTERFACE ---------------
 


### PR DESCRIPTION
해당 퀴즈 목업 모델을 이용하는 경우 `Module not found: Error: Can't resolve` 에러가 발생하던 문제를 수정했습니다.